### PR TITLE
Fix navbar navigation routes from hash links to page paths

### DIFF
--- a/Client/src/components/layout/Navbar.tsx
+++ b/Client/src/components/layout/Navbar.tsx
@@ -7,11 +7,11 @@ import { useTheme } from "@/components/theme-provider";
 
 
 const navLinks = [
-  { title: "Home", href: "#home" },
-  { title: "Projects", href: "#projects" },
-  { title: "About", href: "#about" },
-  { title: "Career", href: "#experience" },
-  { title: "Contact", href: "#contact" },
+  { title: "Home", href: "/" },
+  { title: "Projects", href: "/projects" },
+  { title: "About", href: "/#about" },
+  { title: "Career", href: "/#experience" },
+  { title: "Contact", href: "/#contact" },
 ];
 
 const Navbar = () => {
@@ -46,7 +46,7 @@ const Navbar = () => {
     >
       <div className="container flex items-center justify-between">
         <motion.a
-          href="#home"
+          href="/"
           className="text-xl font-bold"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}


### PR DESCRIPTION
## Summary
Fixes the Navbar navigation links by replacing hash-based scroll anchors with proper page routes to enable seamless navigation between different pages.

## Changes
* **Route Links:** Updated `href` attributes from `#home`, `#projects`, etc., to proper path routes (`/`, `/projects`, etc.).
* **Navigation Behavior:** Ensures clicking navbar links triggers route changes across pages instead of attempting to scroll within the current page.