### PR TITLE
fix(navbar): update projects navigation link to anchor tag

### DIFF
--- a/Client/src/components/layout/Navbar.tsx
+++ b/Client/src/components/layout/Navbar.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "@/components/theme-provider";
 
 const navLinks = [
   { title: "Home", href: "/" },
-  { title: "Projects", href: "/projects" },
+  { title: "Projects", href: "/#projects" },
   { title: "About", href: "/#about" },
   { title: "Career", href: "/#experience" },
   { title: "Contact", href: "/#contact" },


### PR DESCRIPTION
## Summary
Updated the navigation link for "Projects" in `Navbar.tsx` to point to `/#projects` instead of `/projects`.

## Reason for Change
- Directs users seamlessly to the Projects section on the primary landing page instead of routing to a separate page route.
- Improves overall page navigation flow and user experience.

## Changes Made
- Changed `href: "/projects"` to `href: "/#projects"` in `Navbar.tsx`.